### PR TITLE
osc operator = redesign

### DIFF
--- a/sim.c
+++ b/sim.c
@@ -370,23 +370,23 @@ BEGIN_OPERATOR(midi)
 END_OPERATOR
 
 BEGIN_OPERATOR(osc)
-  PORT(0, -2, IN | PARAM);
-  PORT(0, -1, IN | PARAM);
-  Usz len = index_of(PEEK(0, -1)) + 1;
+  PORT(0, 2, IN | PARAM);
+  PORT(0, 1, IN | PARAM);
+  Usz len = index_of(PEEK(0, 1)) + 1;
   if (len > Oevent_osc_int_count)
     len = Oevent_osc_int_count;
   for (Usz i = 0; i < len; ++i) {
     PORT(0, (Isz)i + 1, IN);
   }
   STOP_IF_NOT_BANGED;
-  Glyph g = PEEK(0, -2);
+  Glyph g = PEEK(0, 2);
   if (g != '.') {
-    Usz len = index_of(PEEK(0, -1)) + 1;
+    Usz len = index_of(PEEK(0, 1)) + 1;
     if (len > Oevent_osc_int_count)
       len = Oevent_osc_int_count;
     U8 buff[Oevent_osc_int_count];
     for (Usz i = 0; i < len; ++i) {
-      buff[i] = (U8)index_of(PEEK(0, (Isz)i + 1));
+      buff[i] = (U8)index_of(PEEK(0, (Isz)i + 3));
     }
     Oevent_osc_ints* oe =
         &oevent_list_alloc_item(extra_params->oevent_list)->osc_ints;


### PR DESCRIPTION
ok, with this the osc operator will be `=3x0246` instead of `x3=0245` where `x` is the address as `/x`, `3` is the length (in orca-c the lenght is still 1 less than in orca) and the even numbers are the arguments.