### PR TITLE
Backspace character deletion

### DIFF
--- a/tui_main.c
+++ b/tui_main.c
@@ -2364,6 +2364,14 @@ int main(int argc, char** argv) {
       break;
     case 127: // backspace in terminal.app, apparently
     case KEY_BACKSPACE:
+      if (ged_state.input_mode == Ged_input_mode_append) {
+        ged_dir_input(&ged_state, Ged_dir_left, 1);
+        ged_input_character(&ged_state, '.');
+        ged_dir_input(&ged_state, Ged_dir_left, 1);
+      } else {
+        ged_input_character(&ged_state, '.');
+      }
+      break;
     case CTRL_PLUS('h'):
     case KEY_LEFT:
       ged_dir_input(&ged_state, Ged_dir_left, 1);


### PR DESCRIPTION
added deletion behavior for backspace key.

backspace is implemented as it needed to be: the cursor deletes characters before the cursor's position in append mode.

```cpp
case KEY_BACKSPACE:
      if (ged_state.input_mode == Ged_input_mode_append) {
        ged_dir_input(&ged_state, Ged_dir_left, 1);
        ged_input_character(&ged_state, '.');
        ged_dir_input(&ged_state, Ged_dir_left, 1);
      } else {
        ged_input_character(&ged_state, '.');
      }
      break;
```

but i noticed that in js version there the cursor is right on the character, and in c it would look like this

```cpp
case KEY_BACKSPACE:
      ged_input_character(&ged_state, '.');
      if (ged_state.input_mode == Ged_input_mode_append) {
        ged_dir_input(&ged_state, Ged_dir_left, 2);
      }
      break;
```