### PR TITLE
Fix Variable

### DIFF
--- a/sim.c
+++ b/sim.c
@@ -671,7 +671,7 @@ END_OPERATOR
 BEGIN_OPERATOR(variable)
   LOWERCASE_REQUIRES_BANG;
   PORT(0, -1, IN | PARAM);
-  PORT(0, 1, IN | PARAM);
+  PORT(0, 1, IN);
   Glyph left = PEEK(0, -1);
   Glyph right = PEEK(0, 1);
   if (left != '.') {


### PR DESCRIPTION
Inputs on the right side of the operator are not marked with PARAM
(which denotes a haste input).  This fixes the display of the variable
operator so that the text on the right is displayed white and not cyan;
which matches Orca.

Here's the bug, as shown in Orca-c
![image](https://user-images.githubusercontent.com/120447/77413507-5c1bf400-6db7-11ea-9862-0a951b14c1e2.png)

And here's how it should look in Orca.
![image](https://user-images.githubusercontent.com/120447/77413537-69d17980-6db7-11ea-96ce-dfeeca5df8a0.png)



