### PR TITLE
tui_main: update according to #60

### DIFF
--- a/tui_main.c
+++ b/tui_main.c
@@ -2246,7 +2246,7 @@ static void push_opers_guide_msg(void) {
   };
   static struct Guide_item items[] = {
       {'A', "add", "Outputs sum of inputs."},
-      {'B', "between", "Outputs subtraction of inputs."},
+      {'B', "subtract", "Outputs difference of inputs."},
       {'C', "clock", "Outputs modulo of frame."},
       {'D', "delay", "Bangs on modulo of frame."},
       {'E', "east", "Moves eastward, or bangs."},


### PR DESCRIPTION
`bounce` → `subtract`

I have a change in plan 9 fork that adds the "help" (guide?) string for the cell under cursor like in the js version that I'm gonna try porting to the unix part of orca-c, which perhaps could include the guide items generated from the macro calls in `sim.c` instead.