### PR TITLE
Proposal: Commander (`$`) operator and utils.

### DIFF
--- a/base.h
+++ b/base.h
@@ -108,6 +108,7 @@ static bool orca_is_valid_glyph(Glyph c) {
   case ';':
   case '=':
   case '?':
+  case '$':
     return true;
   }
   return false;

--- a/cli_main.c
+++ b/cli_main.c
@@ -1,4 +1,4 @@
-#include "base.h"
+#include "state.h"
 #include "field.h"
 #include "gbuffer.h"
 #include "sim.h"
@@ -86,13 +86,18 @@ int main(int argc, char **argv) {
   oevent_list_init(&oevent_list);
   Usz max_ticks = (Usz)ticks;
 
-  // TODO should this be a param?
-  Usz bpm = 0;
+  State state;
+  state.tick_num = 0;
+  state.bpm = (Usz) 120;
+  state.oosc_dev = NULL;
+  state.is_playing = true;
+
   for (Usz i = 0; i < max_ticks; ++i) {
+    state.tick_num = i;
     mbuffer_clear(mbuf_r.buffer, field.height, field.width);
     oevent_list_clear(&oevent_list);
-    orca_run(field.buffer, mbuf_r.buffer, field.height, field.width, i,
-             &oevent_list, 0, &bpm);
+    orca_run(field.buffer, mbuf_r.buffer, field.height, field.width,
+             &oevent_list, 0, &state);
   }
   mbuf_reusable_deinit(&mbuf_r);
   oevent_list_deinit(&oevent_list);

--- a/cli_main.c
+++ b/cli_main.c
@@ -85,11 +85,14 @@ int main(int argc, char **argv) {
   Oevent_list oevent_list;
   oevent_list_init(&oevent_list);
   Usz max_ticks = (Usz)ticks;
+
+  // TODO should this be a param?
+  Usz bpm = 0;
   for (Usz i = 0; i < max_ticks; ++i) {
     mbuffer_clear(mbuf_r.buffer, field.height, field.width);
     oevent_list_clear(&oevent_list);
     orca_run(field.buffer, mbuf_r.buffer, field.height, field.width, i,
-             &oevent_list, 0);
+             &oevent_list, 0, &bpm);
   }
   mbuf_reusable_deinit(&mbuf_r);
   oevent_list_deinit(&oevent_list);

--- a/commander.c
+++ b/commander.c
@@ -1,0 +1,48 @@
+#include "commander.h"
+#include <stdlib.h>
+#include <string.h>
+
+void parse_command(Glyph *command, State *state) {
+  const Glyph end_line[2] = ".";
+  Glyph *token;
+  token = strtok(command, end_line);
+  while (token != NULL) {
+    // Parse simple tokens
+    if (strcmp(token, "play") == 0) {
+      state->is_playing = true;
+    } else if (strcmp(token, "stop") == 0) {
+      state->is_playing = false;
+    } else if (strcmp(token, "run") == 0) {
+      state->tick_num++;
+    } else {
+      const Glyph arguments_separator[2] = ":";
+      token = strtok(command, arguments_separator);
+      while(token != NULL) {
+        // TODO handle errors: https://stackoverflow.com/questions/15229411/input-validation-of-an-integer-using-atoi
+        if (strcmp(token, "bpm") == 0) {
+          token = strtok(NULL, end_line);
+          if (token == NULL) return;
+          Glyph *end_ptr;
+          state->bpm = (Usz) strtoul(token, &end_ptr, 10);
+        } else if (strcmp(token, "frame") == 0) {
+          token = strtok(NULL, end_line);
+          if (token == NULL) return;
+          Glyph *end_ptr;
+          state->tick_num = (Usz) strtoul(token, &end_ptr, 10);
+        } else if (strcmp(token, "rewind") == 0) {
+          token = strtok(NULL, end_line);
+          if (token == NULL) return;
+          Glyph *end_ptr;
+          state->tick_num -= (Usz) strtoul(token, &end_ptr, 10);
+        } else if (strcmp(token, "skip") == 0) {
+          token = strtok(NULL, end_line);
+          if (token == NULL) return;
+          Glyph *end_ptr;
+          state->tick_num += (Usz) strtoul(token, &end_ptr, 10);
+        }
+        token = strtok(NULL, arguments_separator);
+      }
+    }
+    token = strtok(NULL, end_line);
+  }
+}

--- a/commander.h
+++ b/commander.h
@@ -1,0 +1,5 @@
+#pragma once
+#include "base.h"
+#include "state.h"
+
+void parse_command(Glyph *command, State *state);

--- a/sim.c
+++ b/sim.c
@@ -1,7 +1,5 @@
 #include "sim.h"
 #include "gbuffer.h"
-// TODO remove stdio after testing
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/sim.c
+++ b/sim.c
@@ -1,7 +1,6 @@
 #include "sim.h"
+#include "commander.h"
 #include "gbuffer.h"
-#include <stdlib.h>
-#include <string.h>
 
 //////// Utilities
 
@@ -423,50 +422,7 @@ BEGIN_OPERATOR(commander)
   // TODO revise if necessary
   if (PEEK(0, 1) == '.') return;
 
-  // TODO define parser macro
-  const Glyph end_line[2] = ".";
-  Glyph *token;
-  token = strtok(cpy, end_line);
-  while (token != NULL) {
-    // Parse simple tokens
-    // TODO finish
-    if (strcmp(token, "play") == 0) {
-      state->is_playing = true;
-    } else if (strcmp(token, "stop") == 0) {
-      state->is_playing = false;
-    } else if (strcmp(token, "run") == 0) {
-      state->tick_num++;
-    } else {
-      const Glyph arguments_separator[2] = ":";
-      token = strtok(cpy, arguments_separator);
-      while(token != NULL) {
-        // TODO handle errors: https://stackoverflow.com/questions/15229411/input-validation-of-an-integer-using-atoi
-        if (strcmp(token, "bpm") == 0) {
-          token = strtok(NULL, end_line);
-          if (token == NULL) return;
-          Glyph *end_ptr;
-          state->bpm = (Usz) strtoul(token, &end_ptr, 10);
-        } else if (strcmp(token, "frame") == 0) {
-          token = strtok(NULL, end_line);
-          if (token == NULL) return;
-          Glyph *end_ptr;
-          state->tick_num = (Usz) strtoul(token, &end_ptr, 10);
-        } else if (strcmp(token, "rewind") == 0) {
-          token = strtok(NULL, end_line);
-          if (token == NULL) return;
-          Glyph *end_ptr;
-          state->tick_num -= (Usz) strtoul(token, &end_ptr, 10);
-        } else if (strcmp(token, "skip") == 0) {
-          token = strtok(NULL, end_line);
-          if (token == NULL) return;
-          Glyph *end_ptr;
-          state->tick_num += (Usz) strtoul(token, &end_ptr, 10);
-        }
-        token = strtok(NULL, arguments_separator);
-      }
-    }
-    token = strtok(NULL, end_line);
-  }
+  parse_command(cpy, state);
 
 END_OPERATOR
 

--- a/sim.h
+++ b/sim.h
@@ -1,7 +1,6 @@
 #pragma once
-#include "base.h"
+#include "state.h"
 #include "vmio.h"
 
 void orca_run(Glyph *restrict gbuffer, Mark *restrict mbuffer, Usz height,
-              Usz width, Usz *tick_number, Oevent_list *oevent_list,
-              Usz random_seed, Usz *bpm);
+              Usz width, Oevent_list *oevent_list, Usz random_seed, State *state);

--- a/sim.h
+++ b/sim.h
@@ -3,5 +3,5 @@
 #include "vmio.h"
 
 void orca_run(Glyph *restrict gbuffer, Mark *restrict mbuffer, Usz height,
-              Usz width, Usz tick_number, Oevent_list *oevent_list,
-              Usz random_seed);
+              Usz width, Usz *tick_number, Oevent_list *oevent_list,
+              Usz random_seed, Usz *bpm);

--- a/state.h
+++ b/state.h
@@ -1,0 +1,11 @@
+#pragma once
+#include "base.h"
+#include "osc_out.h"
+
+typedef struct {
+  Usz tick_num;
+  Usz bpm;
+  bool is_playing : 1;
+  Oosc_dev *oosc_dev;
+
+} State;

--- a/sysmisc.c
+++ b/sysmisc.c
@@ -122,7 +122,7 @@ Conf_read_result conf_read_line(FILE *file, char *buf, Usz bufsize,
     if (a0 == len)
       goto ignore;
     char c = s[a0];
-    if (c == ';' || c == '#') // comment line, ignore
+    if (c == ';' || c == '#' || c == '$') // comment line, ignore
       goto ignore;
     if (c == '=') // '=' before any other char, bad
       goto ignore;

--- a/tool
+++ b/tool
@@ -335,7 +335,7 @@ build_target() {
       out_exe=cli
     ;;
     orca|tui)
-      add source_files osc_out.c term_util.c sysmisc.c thirdparty/oso.c tui_main.c
+      add source_files commander.c osc_out.c term_util.c sysmisc.c thirdparty/oso.c tui_main.c
       add cc_flags -D_XOPEN_SOURCE_EXTENDED=1
       # thirdparty headers (like sokol_time.h) should get -isystem for their
       # include dir so that any warnings they generate with our warning flags

--- a/tui_main.c
+++ b/tui_main.c
@@ -1259,12 +1259,11 @@ static double ged_secs_to_deadline(Ged const *a) {
 }
 
 staticni void clear_and_run_vm(Glyph *restrict gbuf, Mark *restrict mbuf,
-                               Usz height, Usz width, Usz *tick_number,
-                               Oevent_list *oevent_list, Usz random_seed,
-                               Usz *bpm) {
+                               Usz height, Usz width, Oevent_list *oevent_list,
+                               Usz random_seed, State *state) {
   mbuffer_clear(mbuf, height, width);
   oevent_list_clear(oevent_list);
-  orca_run(gbuf, mbuf, height, width, tick_number, oevent_list, random_seed, bpm);
+  orca_run(gbuf, mbuf, height, width, oevent_list, random_seed, state);
 }
 
 staticni void ged_do_stuff(Ged *a) {
@@ -1323,8 +1322,8 @@ staticni void ged_do_stuff(Ged *a) {
   apply_time_to_sustained_notes(oosc_dev, midi_mode, secs_span,
                                 &a->susnote_list, &a->time_to_next_note_off);
   clear_and_run_vm(a->field.buffer, a->mbuf_r.buffer, a->field.height,
-                   a->field.width, &a->state.tick_num, &a->oevent_list,
-                   a->random_seed, &a->state.bpm);
+                   a->field.width, &a->oevent_list, a->random_seed,
+                   &a->state);
   ++a->state.tick_num;
   a->needs_remarking = true;
   a->is_draw_dirty = true;
@@ -1428,8 +1427,8 @@ staticni void ged_draw(Ged *a, WINDOW *win, char const *filename,
     field_copy(&a->field, &a->scratch_field);
     mbuf_reusable_ensure_size(&a->mbuf_r, a->field.height, a->field.width);
     clear_and_run_vm(a->scratch_field.buffer, a->mbuf_r.buffer, a->field.height,
-                     a->field.width, &a->state.tick_num, &a->scratch_oevent_list,
-                     a->random_seed, &a->state.bpm);
+                     a->field.width, &a->scratch_oevent_list, a->random_seed,
+                     &a->state);
     a->needs_remarking = false;
   }
   int win_w = a->win_w;
@@ -1884,8 +1883,8 @@ staticni void ged_input_cmd(Ged *a, Ged_input_cmd ev) {
   case Ged_input_cmd_step_forward:
     undo_history_push(&a->undo_hist, &a->field, a->state.tick_num);
     clear_and_run_vm(a->field.buffer, a->mbuf_r.buffer, a->field.height,
-                     a->field.width, &a->state.tick_num, &a->oevent_list,
-                     a->random_seed, &a->state.bpm);
+                     a->field.width, &a->oevent_list, a->random_seed,
+                     &a->state);
     ++a->state.tick_num;
     a->activity_counter += a->oevent_list.count;
     a->needs_remarking = true;


### PR DESCRIPTION
# Preface:
The other day I was watching this [tutorial](https://youtu.be/ktcWOLeWP-g) featured in the OrcaJS repo, and I found out that adjusting the BPM programmatically (as seen [here](https://youtu.be/ktcWOLeWP-g?t=1509)) wasn't an option, so I decided to try and implement that, along with some of the other features from the commander interface.

I haven't programmed anything in C beyond some `"hello world"` stuff (I come from a JS background) and this PR is the result of reverse engineering the really comprehensible code written in this repo + some web search :smile: .

---


# Changes:

## Menu

* Added menu option under help for the `Crtl + G` command to show operators.

## Implemented Orca `commander` interface:

### State (`state.h`):
* Abstracted values that could be altered via commands to a new struct called `State`\*, it saves `bpm`, `tick_num`, `is_playing` and `*oosc_dev` (that one is still a TODO).
* Implemented this struct through the whole app.

\* This abstraction was necessary to change `is_playing` via reference pointer (without abstracting the whole `Ged` struct). It could still be implemented without struct nesting, changing the type of `is_playing` to `int` and leaving everything inside of the `Ged` struct intact (this could maybe favor performance, but I don't know how much the performance is affected currently by passing a struct vs passing each value individually by reference).

### Commander (`commander.h`, `commander.c`, `sim.h`, `sim.c`, `cli_main.c`, `symisc.c`):
* Implemented `parse_command(Glyph command, State state)` method. This implementation adds the following commands: `play`,`run`, `stop`, `bpm:num`, `frame:num`, `rewind:num` and `skip:num`. It uses `strtok` to obtain tokens, `strcmp` to compare strings and `strtoul` to parse number values.
* Added commander operation, it copies the current buffer with the same values as the UDP parser (this should also be revised) and passes the copy as a command to the `parse_command` method.
* `orca_run` now takes `state` as the only param related to `bpm`, `tick_num`, `is_playing` and `oosc_dev`.

### tool:
* Prioritize compilation of `commander.c` to avoid linking errors.

# Caveats and considerations:
* Perhaps nesting structs isn't the best option for performance in devices that have smaller computing power, but I currently have no means to test this (also addressed in `State` abstraction). This can be mitigated easily removing said abstraction and passing every single value by reference,
* Some stuff is dependent and copied directly from the udp operator code, perhaps it needs some considerations in regards to how commands are parsed (as it copies 16 chars from the buffer in the copy method).
* Maybe some stuff could be abstracted into macros and I'm not considering it.
* There's some issues regarding advancing single frames: sometimes this triggers a double BANG (don't know if it relates to these changes or is a separate issue, but it's simple to view when using the `skip` command).
