### PR TITLE
Update tui_main.c

### DIFF
--- a/tui_main.c
+++ b/tui_main.c
@@ -638,7 +638,7 @@ staticni void draw_oevent_list(WINDOW *win, Oevent_list const *oevent_list) {
     }
     case Oevent_type_osc_ints: {
       Oevent_osc_ints const *eo = &ev->osc_ints;
-      wprintw(win, "OSC\t%c\tcount: %d ", eo->glyph, eo->count, eo->count);
+      wprintw(win, "OSC\t%c\tcount: %d ", eo->glyph, eo->count);
       waddch(win, ACS_VLINE);
       for (Usz j = 0; j < eo->count; ++j) {
         wprintw(win, " %d", eo->numbers[j]);


### PR DESCRIPTION
Fix warning on build with `./tool build -v --portmidi orca`
> data argument not used by format string [-Wformat-extra-args]