### PR TITLE
Ensure console mouse events are turned off on exit

### DIFF
--- a/tui_main.c
+++ b/tui_main.c
@@ -3855,6 +3855,9 @@ quit:
   qnav_deinit();
   if (cont_window)
     delwin(cont_window);
+#ifndef FEAT_NOMOUSE
+  printf("\033[?1003l\n"); // turn off console mouse events if they were active
+#endif
   printf("\033[?2004h\n"); // Tell terminal to not use bracketed paste
   endwin();
   ged_deinit(&t.ged);


### PR DESCRIPTION
If user uses mouse at all during a session, after exiting via CTRL-Q the (Linux) terminal will still spew out mouse events; this patch turns off the XTerm mouse reporting on exit.