### PR TITLE
support Windows clipboard on WSL

### DIFF
--- a/sysmisc.c
+++ b/sysmisc.c
@@ -37,6 +37,8 @@ Cboard_error cboard_copy(Glyph const *gbuffer, Usz field_height,
   FILE *fp =
 #ifdef ORCA_OS_MAC
       popen("pbcopy -pboard general 2>/dev/null", "w");
+#elif defined(ORCA_OS_WSL)
+      popen("clip.exe 2>/dev/null", "w");
 #else
       popen("xclip -i -selection clipboard 2>/dev/null", "w");
 #endif
@@ -58,6 +60,8 @@ Cboard_error cboard_paste(Glyph *gbuffer, Usz height, Usz width, Usz y, Usz x,
   FILE *fp =
 #ifdef ORCA_OS_MAC
       popen("pbpaste -pboard general -Prefer txt 2>/dev/null", "r");
+#elif defined(ORCA_OS_WSL)
+      popen("powershell.exe -command 'Get-Clipboard' 2>/dev/null", "r");
 #else
       popen("xclip -o -selection clipboard 2>/dev/null", "r");
 #endif

--- a/tool
+++ b/tool
@@ -54,7 +54,10 @@ cmd=$1
 shift
 
 case $(uname -s | awk '{print tolower($0)}') in
-  linux*) os=linux;;
+  linux*) os=linux
+          case $(uname -r | awk '{print tolower($0)}') in
+              *-microsoft-standard-wsl2) linux_flavor=wsl;;
+          esac;;
   darwin*) os=mac;;
   cygwin*) os=cygwin;;
   *bsd*) os=bsd;;
@@ -384,6 +387,9 @@ build_target() {
           # librt and high-res posix timers on Linux
           add libraries -lrt
           add cc_flags -D_POSIX_C_SOURCE=200809L
+          if [ "$linux_flavor" = wsl ]; then
+              add cc_flags -DORCA_OS_WSL
+          fi
         ;;
       esac
       # Depending on the Linux distro, ncurses might have been built with tinfo


### PR DESCRIPTION
adds support for interacting with the Windows clipboard when running Orca in WSL (Windows Subsystem for Linux).

caveats:

- unfortunately, clip.exe has no way to retrieve the clipboard content. here a powershell command is used instead, which is quite slow.
  - in practice however, at least in Microsoft's Terminal app, pressing ctrl+v invokes a built-in paste function which works fine. ctrl+alt+v will send ctrl+v to the running program, invoking the slow powershell paste in Orca.
- im not sure if my method of detecting WSL in the build script is ideal
- i suppose a user might possibly want to run Orca in WSL and still use xclip. this is currently not possible with my code